### PR TITLE
Implement CFA study tracker CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+study_data.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# cfa_study
+# CFA Study Tracker
+
+Aplicação simples em Python para acompanhar os estudos do CFA Level 3.
+
+## Uso
+
+```bash
+# Adicionar um novo tópico
+python tracker.py add "Fixed Income"
+
+# Marcar um tópico como concluído
+python tracker.py complete "Fixed Income"
+
+# Listar tópicos cadastrados
+python tracker.py list
+```
+
+Os dados são armazenados no arquivo `study_data.json`. Para alterar o local do arquivo, defina a variável de ambiente `STUDY_DATA_FILE`.

--- a/test_tracker.py
+++ b/test_tracker.py
@@ -1,0 +1,24 @@
+import json
+import os
+import importlib
+
+
+def test_add_and_complete(tmp_path, capsys):
+    data_file = tmp_path / 'data.json'
+    os.environ['STUDY_DATA_FILE'] = str(data_file)
+    tracker = importlib.import_module('tracker')
+
+    tracker.add_task('Ethics')
+    tracker.list_tasks()
+    out = capsys.readouterr().out
+    assert 'Ethics' in out
+    assert '[✗]' in out
+
+    tracker.complete_task('Ethics')
+    tracker.list_tasks()
+    out = capsys.readouterr().out
+    assert '[✓]' in out
+
+    with open(data_file, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data['Ethics'] is True

--- a/tracker.py
+++ b/tracker.py
@@ -1,0 +1,69 @@
+import json
+import argparse
+from pathlib import Path
+import os
+
+DATA_FILE = Path(os.environ.get('STUDY_DATA_FILE', 'study_data.json'))
+
+def load_data():
+    if DATA_FILE.exists():
+        with open(DATA_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {}
+
+def save_data(data):
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+def add_task(topic):
+    data = load_data()
+    if topic in data:
+        print(f'Tópico "{topic}" já existe.')
+        return
+    data[topic] = False
+    save_data(data)
+    print(f'Tópico "{topic}" adicionado.')
+
+def complete_task(topic):
+    data = load_data()
+    if topic not in data:
+        print(f'Tópico "{topic}" não encontrado.')
+        return
+    data[topic] = True
+    save_data(data)
+    print(f'Tópico "{topic}" marcado como concluído.')
+
+def list_tasks():
+    data = load_data()
+    if not data:
+        print('Nenhum tópico cadastrado.')
+        return
+    for topic, done in data.items():
+        status = '✓' if done else '✗'
+        print(f'[{status}] {topic}')
+
+def main():
+    parser = argparse.ArgumentParser(description='Acompanhe seus estudos para o CFA Level 3.')
+    subparsers = parser.add_subparsers(dest='command')
+
+    add_p = subparsers.add_parser('add', help='Adicionar um novo tópico')
+    add_p.add_argument('topic', help='Nome do tópico a ser adicionado')
+
+    comp_p = subparsers.add_parser('complete', help='Marcar um tópico como concluído')
+    comp_p.add_argument('topic', help='Nome do tópico a ser marcado')
+
+    subparsers.add_parser('list', help='Listar tópicos')
+
+    args = parser.parse_args()
+
+    if args.command == 'add':
+        add_task(args.topic)
+    elif args.command == 'complete':
+        complete_task(args.topic)
+    elif args.command == 'list':
+        list_tasks()
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add simple CLI to manage CFA study topics
- store data in `study_data.json` configurable via `STUDY_DATA_FILE`
- add unit test covering tracker functionality
- document usage in README
- ignore data and cache files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686171d2ee00832281be751232fa1f04